### PR TITLE
add ingress rules to allow TCP ports 22, 80, 443

### DIFF
--- a/bountybox/bountybox.tf
+++ b/bountybox/bountybox.tf
@@ -23,8 +23,46 @@ resource "aws_instance" "bountybox" {
   instance_type = "t2.micro"
   key_name      = "${var.key_pair_name}"
 
+  vpc_security_group_ids = ["${aws_security_group.bountybox.id}"]
+  subnet_id = "${aws_subnet.bountybox.id}"
+
   tags = {
     Name = "BountyBox"
   }
 }
 
+resource "aws_security_group" "bountybox" {
+  name_prefix = "bountybox_sg"
+  vpc_id      = "${aws_vpc.bountybox.id}"
+}
+
+# Ingress rules to allow traffic for ssh, http, and https.
+resource "aws_security_group_rule" "allow_ssh" {
+  type        = "ingress"
+  from_port   = 22
+  to_port     = 22
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.bountybox.id}"
+}
+
+resource "aws_security_group_rule" "allow_http" {
+  type        = "ingress"
+  from_port   = 80
+  to_port     = 80
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.bountybox.id}"
+}
+
+resource "aws_security_group_rule" "allow_https" {
+  type        = "ingress"
+  from_port   = 443
+  to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.bountybox.id}"
+}

--- a/bountybox/vpc.tf
+++ b/bountybox/vpc.tf
@@ -1,0 +1,43 @@
+# VPC resources for vpc, subnets, elastic IP, internet gateway, and
+# the routing table.
+resource "aws_vpc" "bountybox" {
+  cidr_block           = "10.0.0.0/16"
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+}
+
+resource "aws_subnet" "bountybox" {
+  vpc_id      = "${aws_vpc.bountybox.id}"
+  cidr_block = "10.0.0.0/24"
+
+  tags = {
+    Name = "bountybox"
+  }
+}
+
+resource "aws_eip" "ip-bountybox" {
+  instance = "${aws_instance.bountybox.id}"
+  vpc      = true
+}
+
+resource "aws_internet_gateway" "bountybox" {
+  vpc_id = "${aws_vpc.bountybox.id}"
+
+  tags = {
+    Name = "bountybox"
+  }
+}
+
+resource "aws_route_table" "bountybox" {
+  vpc_id = "${aws_vpc.bountybox.id}"
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = "${aws_internet_gateway.bountybox.id}"
+  }
+}
+
+resource "aws_route_table_association" "bountybox" {
+  subnet_id      = "${aws_subnet.bountybox.id}"
+  route_table_id = "${aws_route_table.bountybox.id}"
+}


### PR DESCRIPTION
We need to make TCP ports for certain services open for incoming traffic, i.e. 22 for ssh, 80 for HTTP and 443 for HTTPS, because 22 is used for admin controls, 80 & 443 for web interfaces.

For that, we have to define resources for VPC, security groups, an elastic IP, internet gateway, and routing tables. Without defining those resources, the AWS EC2 instance cannot reachable from outside.