### PR TITLE
bountybox: read user_data directly instead of file provisioner

### DIFF
--- a/bountybox/bountybox.tf
+++ b/bountybox/bountybox.tf
@@ -42,6 +42,8 @@ resource "aws_instance" "bountybox" {
   vpc_security_group_ids = ["${aws_security_group.bountybox.id}"]
   subnet_id = "${aws_subnet.bountybox.id}"
 
+  user_data = "${file("${var.distro}/setup-docker.sh")}"
+
   tags = {
     Name = "${var.instance_name}"
   }

--- a/bountybox/provision.tf
+++ b/bountybox/provision.tf
@@ -5,16 +5,4 @@ resource "null_resource" "setup-docker" {
     user = "${lookup(var.distro_user_name, var.distro)}"
     timeout = "3m"
   }
-
-  provisioner "file" {
-    source      = "${var.distro}/setup-docker.sh"
-    destination = "/tmp/setup-docker.sh"
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "chmod +x /tmp/setup-docker.sh",
-      "/tmp/setup-docker.sh",
-    ]
-  }
 }

--- a/bountybox/ubuntu/setup-docker.sh
+++ b/bountybox/ubuntu/setup-docker.sh
@@ -11,6 +11,6 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get -y install apt-transport-https ca-ce
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 sudo apt-get -y install docker-ce docker-ce-cli containerd.io
-sudo usermod -aG docker $USER
+sudo usermod -aG docker ubuntu
 sudo systemctl start docker.service
 sudo systemctl enable docker.service


### PR DESCRIPTION
(draft PR. please do not merge. It depends on https://github.com/kinvolk/container-escape-bounty/pull/5)

We don't need to make use of the file provisioner, because it's possible to read `user_data` directly from the script.

This change results in a side-effect, that `$USER` is not any more `ubuntu`, because it's executed in the early boot context. So we need to use a plain string `ubuntu`.

Note, this mechanism works only for Ubuntu.