### PR TITLE
Set up a testbed that runs contained.af

### DIFF
--- a/bountybox/bountybox.tf
+++ b/bountybox/bountybox.tf
@@ -97,6 +97,16 @@ resource "aws_security_group_rule" "allow_https" {
   security_group_id = "${aws_security_group.bountybox.id}"
 }
 
+resource "aws_security_group_rule" "allow_container" {
+  type        = "ingress"
+  from_port   = 10000
+  to_port     = 10000
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.bountybox.id}"
+}
+
 resource "aws_security_group_rule" "allow_egress" {
   type        = "egress"
   from_port   = 0

--- a/bountybox/bountybox.tf
+++ b/bountybox/bountybox.tf
@@ -106,3 +106,11 @@ resource "aws_security_group_rule" "allow_egress" {
 
   security_group_id = "${aws_security_group.bountybox.id}"
 }
+
+resource "aws_route53_record" "bountybox" {
+  zone_id = "${var.dns_zone_id}"
+  name    = "${var.instance_name}.${var.dns_zone}"
+  type    = "A"
+  ttl     = "300"
+  records  = ["${aws_eip.ip-bountybox.public_ip}"]
+}

--- a/bountybox/ubuntu/cloudinit.yaml
+++ b/bountybox/ubuntu/cloudinit.yaml
@@ -24,6 +24,33 @@ write_files:
       
       [Install]
       WantedBy=multi-user.target
+  - path: /etc/systemd/system/contained.service
+    content: |
+      [Unit]
+      After=docker.service containerd.service
+      Wants=docker.service
+      
+      [Service]
+      Type=simple
+      ExecStart=/tmp/setup-contained.af.sh
+      TimeoutSec=infinity
+      RemainAfterExit=yes
+      
+      [Install]
+      WantedBy=multi-user.target
+  - path: /tmp/setup-contained.af.sh
+    permissions: '0755'
+    content: |
+      #!/bin/bash
+      
+      sudo -u ubuntu /bin/bash -c " \
+        go get -u -v github.com/kinvolk/contained.af; \
+        cd /home/ubuntu/go/src/github.com/kinvolk/contained.af; \
+        git checkout dongsu/kinvolk-demo; \
+        make dev; \
+        make dind; \
+        make run; \
+      "
 packages:
   - apt-transport-https
   - ca-certificates
@@ -41,3 +68,5 @@ runcmd:
   - usermod -aG docker ubuntu
   - systemctl start docker.service
   - systemctl enable docker.service
+  - systemctl start contained.service
+  - systemctl enable contained.service

--- a/bountybox/variables.tf
+++ b/bountybox/variables.tf
@@ -10,6 +10,16 @@ variable "distro" {
   default     = "ubuntu"
 }
 
+variable "dns_zone" {
+  type        = "string"
+  description = "AWS Route53 DNS Zone (e.g. aws.example.com)"
+}
+
+variable "dns_zone_id" {
+  type        = "string"
+  description = "AWS Route53 DNS Zone ID (e.g. 0123456789ABCD)"
+}
+
 variable "instance_name" {
   type        = "string"
   description = "Name of the AWS instance (e.g. BountyBox)"


### PR DESCRIPTION
Set up a testbed that runs `contained.af`. Add a new systemd unit `contained.service`, which runs a script that installs and runs contained.af. For that, add an ingress rule to allow TCP port 10000 needed by contained.af.

Configure DNS zone via route53. Configure a DNS record `${instance_name}.contained.nicht.fun`, like `bountybox.contained.nicht.fun`. To make it work, it's necessary to define `dns_zone` and `dns_zone_id` in `terraform.tfvars`.