### PR TITLE
bountybox: run a Caddy server in front of the backend

### DIFF
--- a/bountybox/bountybox.tf
+++ b/bountybox/bountybox.tf
@@ -36,7 +36,11 @@ data "aws_ami" "ubuntu" {
 }
 
 data "template_file" "systemd" {
-  template = "${file("${var.distro}/cloudinit.yaml")}"
+  template = "${file("${var.distro}/cloudinit.yaml.tmpl")}"
+
+  vars = {
+    domain = "${var.instance_name}.${var.dns_zone}"
+  }
 }
 
 data "template_cloudinit_config" "config" {

--- a/bountybox/ubuntu/cloudinit.yaml.tmpl
+++ b/bountybox/ubuntu/cloudinit.yaml.tmpl
@@ -1,5 +1,34 @@
 #cloud-config
 write_files:
+  - path: /etc/caddy/Caddyfile
+    permissions: '0644'
+    content: |
+      ${domain} {
+        proxy  / http://localhost:10000
+        root   /var/www/${domain}
+        log    stdout
+        errors stdout
+      }
+  - path: /etc/systemd/system/caddy.service
+    content: |
+      [Unit]
+      After=network-online.target
+      Wants=network-online.target
+      
+      [Service]
+      User=www-data
+      Group=www-data
+      Environment=CADDYPATH=/var/www/${domain}
+      RestartSec=10
+      Restart=always
+      LimitNOFILE=32768
+      LimitNPROC=512
+      TimeoutStartSec=300
+      ExecStart=/usr/local/bin/caddy --conf=/etc/caddy/Caddyfile
+      ExecReload=/bin/kill -USR1 $MAINPID
+      
+      [Install]
+      WantedBy=multi-user.target
   - path: /etc/systemd/system/docker.service
     content: |
       [Unit]
@@ -70,3 +99,11 @@ runcmd:
   - systemctl enable docker.service
   - systemctl start contained.service
   - systemctl enable contained.service
+  - curl https://getcaddy.com | bash -s personal
+  - chown root:root /usr/local/bin/caddy
+  - chmod 755 /usr/local/bin/caddy
+  - setcap 'cap_net_bind_service=+ep' /usr/local/bin/caddy
+  - mkdir -p /var/www
+  - chown -R www-data:www-data /var/www
+  - systemctl enable caddy.service
+  - systemctl start caddy.service

--- a/bountybox/ubuntu/cloudinit.yaml.tmpl
+++ b/bountybox/ubuntu/cloudinit.yaml.tmpl
@@ -4,7 +4,10 @@ write_files:
     permissions: '0644'
     content: |
       ${domain} {
-        proxy  / http://localhost:10000
+        proxy  / http://localhost:10000 {
+          transparent
+          websocket
+        }
         root   /var/www/${domain}
         log    stdout
         errors stdout


### PR DESCRIPTION
Run a Caddy webserver as a proxy to the backend contained.af.
We need to create a systemd unit file as well as a simple Caddyfile, so all the incoming connections are redirected to `localhost:10000`.
Doing that, end users don't have to manually connect to hostname:10000.