### PR TITLE
bountybox: directly download gpg key from docker.com

### DIFF
--- a/bountybox/ubuntu/cloudinit.yaml.tmpl
+++ b/bountybox/ubuntu/cloudinit.yaml.tmpl
@@ -94,7 +94,7 @@ packages:
   - software-properties-common
   - systemd
 runcmd:
-  - apt-key adv --recv-keys 0EBFCD88
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
   - add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - apt-get -y install docker-ce docker-ce-cli containerd.io
   - usermod -aG docker ubuntu


### PR DESCRIPTION
It turns out, sometimes apt-key fails to download a correct gpg key from the keyserver.
We should simply download the official key from docker.com.