### PR TITLE
bountybox: support both ubuntu and flatcar using ct provider

### DIFF
--- a/bountybox/flatcar/cloudinit.yaml.tmpl
+++ b/bountybox/flatcar/cloudinit.yaml.tmpl
@@ -1,0 +1,139 @@
+---
+systemd:
+  units:
+    - name: contained-setup.service
+      enable: true
+      contents: |
+        [Unit]
+        Before=contained.service
+        After=network-online.target
+        Wants=network-online.target
+        
+        [Service]
+        Type=simple
+        ExecStartPre=/usr/bin/mkdir -p /opt/bin
+        ExecStart=/opt/bin/setup-contained.af.sh
+        TimeoutSec=infinity
+        RemainAfterExit=yes
+        
+        [Install]
+        WantedBy=multi-user.target
+    - name: contained.service
+      enable: true
+      contents: |
+        [Unit]
+        After=contained-setup docker.service
+        Wants=contained-setup docker.service
+        
+        [Service]
+        Type=simple
+        ExecStart=/opt/bin/run-contained.af.sh
+        TimeoutSec=infinity
+        RestartSec=5
+        Restart=always
+        RemainAfterExit=yes
+        WorkingDirectory=${local_git_repo}
+        
+        [Install]
+        WantedBy=multi-user.target
+    - name: caddy.service
+      enable: true
+      contents: |
+        [Unit]
+        After=network-online.target
+        Wants=network-online.target
+        
+        [Service]
+        Type=simple
+        RestartSec=10
+        Restart=always
+        LimitNOFILE=32768
+        LimitNPROC=512
+        TimeoutStartSec=300
+        ExecStartPre=/usr/bin/mkdir -p /var/www/${domain}
+        ExecStartPre=/usr/bin/chown -R core /var/www/${domain}
+        ExecStartPre=-/usr/bin/rkt rm --uuid-file=/var/lib/caddy-pod-uuid
+        ExecStart=/usr/bin/rkt run \
+        --uuid-file-save=/var/lib/caddy-pod-uuid \
+        --insecure-options=image \
+        --net=host \
+        --dns=host \
+        --volume caddy-dir,kind=host,source=/etc/caddy --mount volume=caddy-dir,target=/etc/caddy \
+        --volume builds-developer-dir,kind=host,source=/var/www/${domain} --mount volume=builds-developer-dir,target=${domain} \
+        --volume caddy-file,kind=host,source=/etc/caddy/Caddyfile --mount volume=caddy-file,target=/etc/Caddyfile \
+        docker://schu/caddy:0.11.0 \
+        --environment=CADDYPATH=/etc/caddy
+        ExecStop=/usr/bin/rkt stop --uuid-file=/var/lib/caddy-pod-uuid
+        ExecReload=/bin/kill -USR1 $MAINPID
+        
+        [Install]
+        WantedBy=multi-user.target
+    - name: docker.service
+      enable: true
+      contents: |
+        [Unit]
+        BindsTo=containerd.service
+        After=network-online.target containerd.service contained-setup.service
+        Wants=network-online.target contained-setup.service
+        Requires=docker.socket
+        
+        [Service]
+        Type=notify
+        ExecStart=/usr/bin/dockerd --host=tcp://127.0.0.1:2375 --host=unix:///var/run/docker.sock --storage-driver=overlay2 --tlsverify --tlscacert=${local_git_repo}/.certs/cacert.pem --tlskey=${local_git_repo}/.certs/server.key --tlscert=${local_git_repo}/.certs/server.cert
+        ExecReload=/bin/kill -s HUP $MAINPID
+        TimeoutSec=0
+        RestartSec=2
+        Restart=always
+        LimitNOFILE=infinity
+        LimitNPROC=infinity
+        LimitCORE=infinity
+        TasksMax=infinity
+        Delegate=yes
+        KillMode=process
+        
+        [Install]
+        WantedBy=multi-user.target
+storage:
+  files:
+    - path: /etc/caddy/Caddyfile
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: |
+          ${domain} {
+            proxy  / http://localhost:10000 {
+              transparent
+              websocket
+            }
+            root   /var/www/${domain}
+            log    stdout
+            errors stdout
+          }
+    - path: /opt/bin/setup-contained.af.sh
+      filesystem: root
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          
+          sudo -u core /bin/bash -c " \
+            mkdir --parents /home/core/go/src/github.com/kinvolk; \
+            cd /home/core/go/src/github.com/kinvolk; \
+            git clone https://github.com/kinvolk/contained.af; \
+            cd contained.af; \
+            git checkout dongsu/kinvolk-demo-flatcar; \
+            mkdir --parents .certs; \
+            ./config/setup_certs.sh; \
+          "
+    - path: /opt/bin/run-contained.af.sh
+      filesystem: root
+      mode: 0755
+      contents:
+        inline: |
+          #!/bin/bash
+          
+          sudo -u core /bin/bash -c " \
+            cd ${local_git_repo}; \
+            ./setup-nodejs-dev.sh; \
+            ./run-contained.sh; \
+          "

--- a/bountybox/ubuntu/cloudinit.yaml.tmpl
+++ b/bountybox/ubuntu/cloudinit.yaml.tmpl
@@ -94,7 +94,7 @@ packages:
   - software-properties-common
   - systemd
 runcmd:
-  - apt-key adv --recv-keys 0EBFCD88
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
   - add-apt-repository "deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
   - apt-get -y install docker-ce docker-ce-cli containerd.io
   - usermod -aG docker ubuntu

--- a/bountybox/ubuntu/cloudinit.yaml.tmpl
+++ b/bountybox/ubuntu/cloudinit.yaml.tmpl
@@ -77,7 +77,7 @@ write_files:
       
       sudo -u ubuntu /bin/bash -c " \
         go get -u -v github.com/kinvolk/contained.af; \
-        cd /home/ubuntu/go/src/github.com/kinvolk/contained.af; \
+        cd ${local_git_repo}; \
         git checkout dongsu/kinvolk-demo; \
         make dev; \
         make dind; \


### PR DESCRIPTION
(draft PR. please do not merge)

Support both ubuntu and flatcar, making use of terraform-provider-ct.

It's based on https://github.com/kinvolk/contained.af/tree/dongsu/kinvolk-demo-flatcar, which is also highly experimental.
I had to write several bash scripts, because there's no make on Flatcar. Also I replaced docker-dind with plain docker-run. These decisions are open to discussions.

In general, it's not really great to keep two different kinds of cloud init configs like that. Though I just followed a conventional way of other projects like typhoon.