### PR TITLE
provision a secret flag file in /var/tmp/FLAG

### DIFF
--- a/terraform/flagfiles.tf
+++ b/terraform/flagfiles.tf
@@ -1,0 +1,5 @@
+resource "random_string" "flag_in_var_tmp" {
+  length = 32
+  special = false
+}
+

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,0 +1,5 @@
+output "flag_in_var_tmp" {
+  value = "${random_string.flag_in_var_tmp.result}"
+  sensitive = true
+}
+

--- a/terraform/provision.tf
+++ b/terraform/provision.tf
@@ -14,4 +14,8 @@ resource "null_resource" "provision" {
   provisioner "remote-exec" {
     inline = "domain='${local.domain}' bash ~/provisioning/${var.distro}.bash"
   }
+
+  provisioner "remote-exec" {
+    inline = "sudo sh -c \"echo ${random_string.flag_in_var_tmp.result} > /var/tmp/FLAG && chmod 0600 /var/tmp/FLAG\""
+  }
 }


### PR DESCRIPTION
Example of output:
```
Apply complete! Resources: 16 added, 0 changed, 0 destroyed.

Outputs:

flag_in_var_tmp = <sensitive>
```

Checking the value of the flag:
```
$ jq '.modules[].outputs.flag_in_var_tmp' ./terraform/terraform.tfstate
{
  "sensitive": true,
  "type": "string",
  "value": "gpA5cS3z3ULrWOY6rVMeN2Qn6v205tPK"
}
```

Verification on the node:
```
$ ssh ubuntu@18.194.202.194 cat /var/tmp/FLAG
gpA5cS3z3ULrWOY6rVMeN2Qn6v205tPK
```