### PR TITLE
app image: Default to the auto built image

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -48,5 +48,5 @@ variable "instance_type" {
 variable "contained_af_image" {
   type        = "string"
   description = "Image to use for contained.af"
-  default     = "quay.io/kinvolk/contained.af:container-escape-bounty-latest"
+  default     = "quay.io/kinvolk/contained.af:container-escape-bounty"
 }


### PR DESCRIPTION
Change the default value of the terraform variable `contained_af_image`
to the image that is automatically built on quay on every commit merge.