### PR TITLE
caddy: Add selinux label change attribute for volumemount

### DIFF
--- a/terraform/provisioning/common.bash
+++ b/terraform/provisioning/common.bash
@@ -41,7 +41,7 @@ common::caddy_run() {
     --name caddy \
     --network host \
     --volume=/etc/caddy/Caddyfile:/etc/Caddyfile:ro \
-    --volume=/var/lib/caddy/dotcaddy:/root/.caddy:rw \
+    --volume=/var/lib/caddy/dotcaddy:/root/.caddy:rw,Z \
     quay.io/schu/caddy:0.11.5
 }
 


### PR DESCRIPTION
Caddy server has a host path volume mounted in the container, where this
container writes. With SELinux enabled this behavior won't be allowed
hence container on Fedora fails and never runs.

To modify the selinux label of the host file or directory being mounted
into the container, we have used selinux option `Z`.