### PR TITLE
fedora: fix release version

### DIFF
--- a/terraform/machine.tf
+++ b/terraform/machine.tf
@@ -36,7 +36,7 @@ data "aws_ami" "fedora" {
 
   filter {
     name   = "name"
-    values = ["Fedora-Cloud-Base-*.x86_64-hvm-*"]
+    values = ["Fedora-Cloud-Base-29-*.x86_64-hvm-*"]
   }
 
   filter {


### PR DESCRIPTION
Stick to Fedora 30 to avoid jumping to rawhide images. Edit: 29