### PR TITLE
terraform: Provide OS name with '-os' flag

### DIFF
--- a/terraform/provisioning/common.bash
+++ b/terraform/provisioning/common.bash
@@ -46,6 +46,7 @@ common::caddy_run() {
 }
 
 common::contained.af_run() {
+  osname="${1}"
   # We have hardcoded the container names, and it is highly possible that
   # starting container with same name will fail if we already have a
   # running/stopped container. To avoid this script from erroring out on that
@@ -57,7 +58,7 @@ common::contained.af_run() {
     --name contained.af \
     --network host \
     ${contained_af_image} \
-    -d
+    -d -os="${osname}"
 }
 
 if [[ $EUID -eq 0 ]]; then

--- a/terraform/provisioning/fedora.bash
+++ b/terraform/provisioning/fedora.bash
@@ -101,4 +101,4 @@ install_docker_userns
 
 common::caddy_write_config "${domain:?}"
 common::caddy_run
-common::contained.af_run
+common::contained.af_run fedora

--- a/terraform/provisioning/flatcar.bash
+++ b/terraform/provisioning/flatcar.bash
@@ -97,4 +97,4 @@ install_docker_userns
 
 common::caddy_write_config "${domain:?}"
 common::caddy_run
-common::contained.af_run
+common::contained.af_run flatcar

--- a/terraform/provisioning/ubuntu.bash
+++ b/terraform/provisioning/ubuntu.bash
@@ -121,4 +121,4 @@ install_docker_userns
 
 common::caddy_write_config "${domain:?}"
 common::caddy_run
-common::contained.af_run
+common::contained.af_run ubuntu


### PR DESCRIPTION
The application contained.af now supports the flag `-os` according to
which the `index.html` of the application will be rendered.

This PR utilizes the flag added in the PR https://github.com/kinvolk/contained.af/pull/14