### PR TITLE
caddy: use HTTP basic auth to restrict usage

### DIFF
--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -3,6 +3,11 @@ output "flag_in_var_tmp" {
   sensitive = true
 }
 
+output "password" {
+  value     = "${random_string.password.result}"
+  sensitive = true
+}
+
 output "apparmor_machine" {
   value = "https://${local.domain_apparmor}"
 }

--- a/terraform/password.tf
+++ b/terraform/password.tf
@@ -1,0 +1,4 @@
+resource "random_string" "password" {
+  length  = 16
+  special = false
+}

--- a/terraform/provision.tf
+++ b/terraform/provision.tf
@@ -14,7 +14,7 @@ resource "null_resource" "provision" {
   }
 
   provisioner "remote-exec" {
-    inline = "domain='${local.machine_domains[count.index]}' contained_af_image=${var.contained_af_image} bash ~/provisioning/${local.machine_users[count.index]}.bash"
+    inline = "domain='${local.machine_domains[count.index]}' username='${var.username}' password='${random_string.password.result}' contained_af_image=${var.contained_af_image} bash ~/provisioning/${local.machine_users[count.index]}.bash"
   }
 
   provisioner "remote-exec" {

--- a/terraform/provisioning/common.bash
+++ b/terraform/provisioning/common.bash
@@ -13,6 +13,8 @@ common::exit_error() {
 
 common::caddy_write_config() {
   local -r domain="${1}"
+  local -r username="${2}"
+  local -r password="${3}"
   sudo mkdir -p /etc/caddy
   sudo mkdir -p /var/www
   cat <<EOF | sudo tee /etc/caddy/Caddyfile
@@ -24,6 +26,7 @@ ${domain} {
   root   /var/www/
   log    stdout
   errors stdout
+  basicauth / "${username}" "${password}"
 }
 EOF
 }

--- a/terraform/provisioning/fedora.bash
+++ b/terraform/provisioning/fedora.bash
@@ -99,6 +99,6 @@ EOF
 install_docker
 install_docker_userns
 
-common::caddy_write_config "${domain:?}"
+common::caddy_write_config "${domain:?}" "${username:?}" "${password:?}"
 common::caddy_run
 common::contained.af_run fedora

--- a/terraform/provisioning/ubuntu.bash
+++ b/terraform/provisioning/ubuntu.bash
@@ -119,6 +119,6 @@ EOF
 install_docker
 install_docker_userns
 
-common::caddy_write_config "${domain:?}"
+common::caddy_write_config "${domain:?}" "${username:?}" "${password:?}"
 common::caddy_run
 common::contained.af_run ubuntu

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -44,3 +44,9 @@ variable "contained_af_image" {
   description = "Image to use for contained.af"
   default     = "quay.io/kinvolk/contained.af:container-escape-bounty"
 }
+
+variable "username" {
+  type        = "string"
+  description = "Username for the HTTP basic authentification"
+  default     = "user"
+}


### PR DESCRIPTION
The instances were publicly available which
may lead to misuse issues.

The caddy HTTP basic auth password is generated through
terraform in the same way the secret flag is generated.
The username is 'user'.