### PR TITLE
terraform: Output links to the machines

### DIFF
--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -2,3 +2,11 @@ output "flag_in_var_tmp" {
   value     = "${random_string.flag_in_var_tmp.result}"
   sensitive = true
 }
+
+output "apparmor_machine" {
+  value = "https://${local.domain_apparmor}"
+}
+
+output "selinux_machine" {
+  value = "https://${local.domain_selinux}"
+}


### PR DESCRIPTION
The module ouputs the links to Fedora/SELinux and Ubuntu/Apparmor
machines for easy access.

Now you can see output like this at the end of `terraform apply`

```bash
...
null_resource.provision[1] (remote-exec):   Checking Host Key: false
null_resource.provision[1] (remote-exec): Connected!                                    
null_resource.provision[1]: Creation complete after 1m55s (ID: 2646428946843724739)
                                                                                               
Apply complete! Resources: 21 added, 0 changed, 0 destroyed.
                                                                                               
Outputs:                        
                                                                                               
apparmor_machine = https://secure.apparmor.example.com
flag_in_var_tmp = <sensitive>
selinux_machine = https://secure.selinux.example.com

```