### PR TITLE
fedora: switch to Fedora 30 but with docker-ce from Fedora 29

### DIFF
--- a/Documentation/profiles.md
+++ b/Documentation/profiles.md
@@ -28,7 +28,12 @@ The basic container profiles are the following:
 Each basic container profiles have the following variants:
 - *without LSM*
 - *with SELinux*
-- *with Apparmor*
+- *with AppArmor*
+
+On the Fedora 30 VM the variants with SELinux and without are available,
+AppArmor is not present.
+On the Ubuntu 10.04 VM the variants with AppArmor and without are available,
+and SELinux is not present.
 
 ## Description of each container profile
 

--- a/terraform/machine.tf
+++ b/terraform/machine.tf
@@ -19,7 +19,7 @@ data "aws_ami" "fedora" {
 
   filter {
     name   = "name"
-    values = ["Fedora-Cloud-Base-29-*.x86_64-hvm-*"]
+    values = ["Fedora-Cloud-Base-30-*.x86_64-hvm-*"]
   }
 
   filter {

--- a/terraform/provisioning/fedora.bash
+++ b/terraform/provisioning/fedora.bash
@@ -14,7 +14,7 @@ install_docker() {
   sudo dnf config-manager \
   --add-repo \
   https://download.docker.com/linux/fedora/docker-ce.repo
-  sudo dnf install -y docker-ce docker-ce-cli containerd.io
+  sudo dnf install -y --releasever=29 docker-ce docker-ce-cli containerd.io
 
   # By default, Docker doesn't listen on 127.0.0.1:2375
   sudo mkdir -p /etc/systemd/system/docker.service.d


### PR DESCRIPTION
The reason for Fedora 29 packages is that docker-ce is not available
currently: https://github.com/docker/for-linux/issues/600